### PR TITLE
fixed a crash where the gif properties could be nil

### DIFF
--- a/SwiftGifCommon/UIImage+Gif.swift
+++ b/SwiftGifCommon/UIImage+Gif.swift
@@ -60,6 +60,9 @@ extension UIImage {
 
         // Get dictionaries
         let cfProperties = CGImageSourceCopyPropertiesAtIndex(source, index, nil)
+        
+        guard CFDictionaryContainsKey(cfProperties, unsafeAddressOf(kCGImagePropertyGIFDictionary)) else {return 0.1}
+        
         let gifProperties: CFDictionaryRef = unsafeBitCast(
             CFDictionaryGetValue(cfProperties,
                 unsafeAddressOf(kCGImagePropertyGIFDictionary)),


### PR DESCRIPTION
For some reasons the gif properties dictionary is nil sometimes.
This code crashed for me where url is https://media3.giphy.com/media/kZzY6eKKPdIjK/200w_d.gif

```
    if let data = NSData(contentsOfURL: url){
            if let source = CGImageSourceCreateWithData(data, nil) {
                dispatch_async(dispatch_get_main_queue(), {
                    if let updatedCell = collectionView.cellForItemAtIndexPath(indexPath) as? GifCell{
                        updatedCell.imageView.image = UIImage.animatedImageWithSource(source)
                    }
                })
            }
       }
```
